### PR TITLE
ovs-ovsdb: cleanup + OVS DPDK netdev support

### DIFF
--- a/orchestrator/CMakeLists.txt
+++ b/orchestrator/CMakeLists.txt
@@ -96,6 +96,14 @@ IF(ENABLE_KVM-IVSHMEM)
 	ADD_DEFINITIONS(-DENABLE_KVM_IVSHMEM -DENABLE_KVM)
 ENDIF(ENABLE_KVM-IVSHMEM)
 
+OPTION(
+	ENABLE_OVSDB_DPDK
+	"Turn on to support OVS with DPDK netdev using the OVS-OVSDB netwrok controller plugin"
+	OFF
+)
+IF(ENABLE_OVSDB_DPDK)
+	ADD_DEFINITIONS(-DENABLE_OVSDB_DPDK)
+ENDIF(ENABLE_OVSDB_DPDK)
 #################################################################################################################
 
 OPTION(
@@ -479,20 +487,15 @@ IF(ENABLE_DPDK_PROCESSES AND ( (${VSWITCH_IMPLEMENTATION_INDEX} EQUAL 1) OR (${V
 	message(FATAL_ERROR "OvS not supported with Dpdk processes")
 ENDIF(ENABLE_DPDK_PROCESSES AND ( (${VSWITCH_IMPLEMENTATION_INDEX} EQUAL 1) OR (${VSWITCH_IMPLEMENTATION_INDEX} EQUAL 3) ) )
 
-IF(ENABLE_KVM-IVSHMEM AND ( (${VSWITCH_IMPLEMENTATION_INDEX} EQUAL 1) OR (${VSWITCH_IMPLEMENTATION_INDEX} EQUAL 3) ) )
-	#This configuration (ovs (ofconfig/ovsdb) + kvm-ivshmem) is not supported
-	message(FATAL_ERROR "OvS not supported with KVM-IVSHMEM")
-ENDIF(ENABLE_KVM-IVSHMEM AND ( (${VSWITCH_IMPLEMENTATION_INDEX} EQUAL 1) OR (${VSWITCH_IMPLEMENTATION_INDEX} EQUAL 3) ) )
+IF(ENABLE_KVM-IVSHMEM AND (${VSWITCH_IMPLEMENTATION_INDEX} EQUAL 1) )
+	#This configuration (ovs-ofconfig + kvm-ivshmem) is not supported
+	message(FATAL_ERROR "OVS-OFCONFIG not supported with KVM-IVSHMEM")
+ENDIF(ENABLE_KVM-IVSHMEM AND (${VSWITCH_IMPLEMENTATION_INDEX} EQUAL 1) )
 
 IF(ENABLE_KVM-IVSHMEM AND  (${VSWITCH_IMPLEMENTATION_INDEX} EQUAL 0) )
 	#This configuration (xdpd + kvm-ivshmem) is not supported
 	message(FATAL_ERROR "xDPd not supported with KVM-IVSHMEM")
 ENDIF(ENABLE_KVM-IVSHMEM AND  (${VSWITCH_IMPLEMENTATION_INDEX} EQUAL 0) )
-
-IF( (${VSWITCH_IMPLEMENTATION_INDEX} EQUAL 2) AND ENABLE_KVM AND ENABLE_DPDK_PROCESSES )
-	#In case of ovs-dpdk, dpdk processes and kvm (usvhost) cannot be supported at the same time
-	message(FATAL_ERROR "OvS-DPDK does not support DPDK processes and KVM at the same time")
-ENDIF( (${VSWITCH_IMPLEMENTATION_INDEX} EQUAL 2) AND ENABLE_KVM AND ENABLE_DPDK_PROCESSES )
 
 IF( (NOT ENABLE_DOCKER) AND (NOT ENABLE_DPDK_PROCESSES) AND (NOT ENABLE_KVM) AND (NOT ENABLE_KVM-IVSHMEM) )
 	#No execution environment is selected

--- a/orchestrator/network_controller/switch_manager/plugins/ovs-ovsdb/commands.cc
+++ b/orchestrator/network_controller/switch_manager/plugins/ovs-ovsdb/commands.cc
@@ -10,7 +10,8 @@ int rnumber = 1;
 uint64_t dnumber = 1;
 int pnumber = 1, nfnumber = 0;
 
-int id = 0;
+/* Transaction ID */
+static int tid = 0;
 
 /*map use to obtain name of switch from id*/
 map<uint64_t, string> switch_id;
@@ -34,6 +35,24 @@ map<uint64_t, string> port_id;
 map<uint64_t, uint64_t> vl_id;
 /*map use to obtain id of peer vlink from local vlink*/
 map<uint64_t, uint64_t> vl_p;
+
+/**
+ * Build name that is valid as UUID: no '-', no '_' ...
+ */
+string build_port_uuid_name(const string& port_name, uint64_t bridge_no)
+{
+	string p_lc = port_name;
+
+	std::transform(p_lc.begin(), p_lc.end(), p_lc.begin(), ::tolower);
+
+ 	stringstream ss;
+ 	ss << p_lc << 'b' << dnumber;
+	string uuid_name = ss.str();
+
+	std::replace(uuid_name.begin(), uuid_name.end(), '_', 'p');
+	std::replace(uuid_name.begin(), uuid_name.end(), '-', 's');
+	return uuid_name;
+}
 
 //Constructor
 commands::commands(){
@@ -305,7 +324,7 @@ CreateLsiOut* commands::cmd_editconfig_lsi (CreateLsiIn cli, int s){
     params.push_back(second_obj);
 
     root["params"] = params;
-	root["id"] = id;
+	root["id"] = tid;
 
 	w_array.clear();
 	m_array.clear();
@@ -314,7 +333,7 @@ CreateLsiOut* commands::cmd_editconfig_lsi (CreateLsiIn cli, int s){
 	a_array.clear();
 	
 	//Increment transaction id
-	id++;
+	tid++;
 
     string *strr = new string[256];
 
@@ -404,27 +423,12 @@ CreateLsiOut* commands::cmd_editconfig_lsi (CreateLsiIn cli, int s){
 			/*for each network function port in the list of nfs_ports*/
 			for(list<struct nf_port_info>::iterator nfp = nfs_ports.begin(); nfp != nfs_ports.end(); nfp++){
 				add_port(nfp->port_name, dnumber, true, s, nfp->port_type);
-				
-				locale loc;	
+
 				port2.push_back("named-uuid");
-				string str = nfp->port_name;
-				
-				for (string::size_type i=0; i<str.length(); ++i)
-    				str[i] = tolower(str[i], loc);
-    				
-				strcpy(tmp, (char *)(str).c_str());
-				sprintf(temp, "%" PRIu64, dnumber);
-				strcat(tmp, "b");
-				strcat(tmp, temp);
-				strcpy(temp, tmp);
-				
-				for(unsigned int j=0;j<strlen(temp);j++){
-					if(temp[j] == '_')
-						temp[j] = 'p';
-				}
-				
-				//insert this port name into port_n
-				port_l[dnumber].push_back(temp);
+
+				//insert this port name into port_l
+				string uuid_name = build_port_uuid_name(nfp->port_name, dnumber);
+				port_l[dnumber].push_back(uuid_name);
 				
 				/*fill the map ports*/
 				n_ports_1[nfp->port_name] = rnumber-1;
@@ -555,7 +559,7 @@ CreateLsiOut* commands::cmd_editconfig_lsi (CreateLsiIn cli, int s){
 			params.clear();
 			
 			//increment transaction id
-			id++;
+			tid++;
 			
 			l++;
 			
@@ -571,15 +575,13 @@ CreateLsiOut* commands::cmd_editconfig_lsi (CreateLsiIn cli, int s){
 
 void commands::add_port(string p, uint64_t dnumber, bool is_nf_port, int s, PortType port_type){
 	
-	char temp[64] = "", tmp[64] = "";
+	string uuid_name;
 	
     ssize_t nwritten;
 	
 	char read_buf[4096] = "";
 	
 	int r = 0;
-	
-	locale loc;	
 	
 	map<string, unsigned int> ports;
 	
@@ -592,46 +594,26 @@ void commands::add_port(string p, uint64_t dnumber, bool is_nf_port, int s, Port
 	Array third_object;
 	Array fourth_object;
 
-	std::replace( p.begin(), p.end(), '-', '_');  // OVSDB doesn't like '-' in names
 	logger(ORCH_DEBUG_INFO, OVSDB_MODULE_NAME, __FILE__, __LINE__, "add_port(%s,type=%s)", p.c_str(), portTypeToString(port_type).c_str());
 
 	//connect socket
     s = cmd_connect();
 
-	char ifac[64] = "iface";
-    stringstream port_name;
+	char ifac[64];
+    string port_name;
 		
 	//Create the current name of a interface
-	if(!is_nf_port){
-		sprintf(temp, "%d", rnumber);
-		strcat(ifac, temp);
-		
-		strcpy(temp, p.c_str());
-		port_name << p.c_str();
-	}else{
-		string str = p;
-		
-		sprintf(temp, "%d", rnumber);
-		strcat(ifac, temp);
-				
-		//Create port name to lower case
-		for (string::size_type i=0; i<str.length(); ++i)
-    		str[i] = tolower(str[i], loc);
-    				
-    	//Create the current port name
-		strcpy(tmp, (char *)(str).c_str());
-		sprintf(temp, "%" PRIu64, dnumber);
-		strcat(tmp, "b");
-		strcat(tmp, temp);
-		strcpy(temp, tmp);
-				
-		for(unsigned int j=0;j<strlen(temp);j++){
-			if(temp[j] == '_')
-				temp[j] = 'p';
-		}
+	sprintf(ifac, "iface%d", rnumber);
+	if (!is_nf_port) {
+		uuid_name = p;
+		port_name = p;
+	} else {
+		uuid_name = build_port_uuid_name(p, dnumber);
 		
 		/*create name of port --> lsiId_portName*/
-		port_name << dnumber << "_" << p.c_str();
+		stringstream ss;
+		ss << dnumber << "_" << p.c_str();
+		port_name = ss.str();
 	}
 	
 	root["method"] = "transact";
@@ -642,7 +624,6 @@ void commands::add_port(string p, uint64_t dnumber, bool is_nf_port, int s, Port
 	first_obj["table"] = "Interface";
 		
 	/*Insert an Interface*/
-	row["name"] = port_name.str().c_str();
 	if (is_nf_port) {
 		switch (port_type) {
 		case IVSHMEM_PORT:
@@ -657,6 +638,8 @@ void commands::add_port(string p, uint64_t dnumber, bool is_nf_port, int s, Port
 			break;
 		case USVHOST_PORT:
 			row["type"] = "dpdkvhostuser";
+
+			// DPDK TODO: Delete socket to be sure ovs can create it!
 			
 			//XXX the next rows have to be removed when this plugin with support OvS-DPDK
 			logger(ORCH_WARNING, OVSDB_MODULE_NAME, __FILE__, __LINE__, "Currently supported by the OvS-DPDK plugin");
@@ -667,10 +650,10 @@ void commands::add_port(string p, uint64_t dnumber, bool is_nf_port, int s, Port
 		case VETH_PORT:
 		{		
 			//In this case the veth pair needs to be created!
-			stringstream new_port_name;
-			new_port_name << port_name.str() << ".lxc";
+			stringstream peer_port_name;
+			peer_port_name << port_name << ".lxc";
 			stringstream cmd_create_veth_pair;
-			cmd_create_veth_pair << CREATE_VETH_PAIR << " " << port_name.str() << " " << new_port_name.str();
+			cmd_create_veth_pair << CREATE_VETH_PAIR << " " << port_name << " " << peer_port_name.str();
 			logger(ORCH_DEBUG_INFO, OVSDB_MODULE_NAME, __FILE__, __LINE__, "Executing command \"%s\"", cmd_create_veth_pair.str().c_str());
 
 			int retVal = system(cmd_create_veth_pair.str().c_str());
@@ -682,11 +665,7 @@ void commands::add_port(string p, uint64_t dnumber, bool is_nf_port, int s, Port
 			
 			//	The veth pair peer given to the container is the one with the port_name as derived from the NF-FG.
 			//	As a result, the veth pair peer we add to OVS is the one with the decorated name: port_name.lxc
-			row["name"] = new_port_name.str().c_str();
-			
-			port_name.str("");
-			port_name.clear();
-			port_name << new_port_name.str();
+			port_name = peer_port_name.str();
 			break;
 		}
 		default:
@@ -700,6 +679,8 @@ void commands::add_port(string p, uint64_t dnumber, bool is_nf_port, int s, Port
 		if (p.compare(0, 4, "dpdk") == 0)
 			row["type"] = "dpdk";
 	}
+
+	row["name"] = port_name.c_str();
 	
 	row["admin_state"] = "up";
 	row["link_state"] = "up";
@@ -714,12 +695,13 @@ void commands::add_port(string p, uint64_t dnumber, bool is_nf_port, int s, Port
 		
 	row.clear();
 	first_obj.clear();
-			
+
+	/*Insert a port*/
 	first_obj["op"] = "insert";
 	first_obj["table"] = "Port";
 		
 	/*Insert a port*/
-	row["name"] = port_name.str().c_str();
+	row["name"] = port_name.c_str();
 		
 	iface.push_back("set");
 	
@@ -733,12 +715,12 @@ void commands::add_port(string p, uint64_t dnumber, bool is_nf_port, int s, Port
 		
 	first_obj["row"] = row;
 		
-	first_obj["uuid-name"] = temp;
-		
+	first_obj["uuid-name"] = uuid_name.c_str();
+
 	params.push_back(first_obj);
 		
 	//insert this port name into port_l
-	port_l[dnumber].push_back(temp);
+	port_l[dnumber].push_back(uuid_name);
 		
 	row.clear();
 	first_obj.clear();
@@ -785,7 +767,7 @@ void commands::add_port(string p, uint64_t dnumber, bool is_nf_port, int s, Port
 	}
 		
 	port2.push_back("named-uuid");
-	port2.push_back(temp);
+	port2.push_back(uuid_name.c_str());
 	
 	port1.push_back(port2);
 	
@@ -838,7 +820,7 @@ void commands::add_port(string p, uint64_t dnumber, bool is_nf_port, int s, Port
 	port2.clear();
 	root["params"] = params;
 
-	root["id"] = id;
+	root["id"] = tid;
 
 	stringstream ss;
  	write_formatted(root, ss );
@@ -903,7 +885,7 @@ void commands::add_port(string p, uint64_t dnumber, bool is_nf_port, int s, Port
 	params.clear();
 			
 	//Increment transaction id
-	id++;
+	tid++;
 	
 	rnumber++;
 
@@ -916,7 +898,7 @@ void commands::add_port(string p, uint64_t dnumber, bool is_nf_port, int s, Port
     if(is_nf_port && (port_type != USVHOST_PORT) && (port_type != IVSHMEM_PORT))
     {
     	stringstream command;
-		command << ACTIVATE_INTERFACE << " " << p_n;
+		command << ACTIVATE_INTERFACE << " " << port_name;
 		logger(ORCH_DEBUG_INFO, OVSDB_MODULE_NAME, __FILE__, __LINE__, "Executing command \"%s\"",command.str().c_str());
 		int retVal = system(command.str().c_str());
 		retVal = retVal >> 8;
@@ -937,8 +919,6 @@ void commands::cmd_editconfig_lsi_delete(uint64_t dpi, int s){
 	int r = 0;
 	
 	char read_buf[4096] = "";
-	
-	locale loc;	
 	
 	map<string, unsigned int> ports;
 	
@@ -1033,7 +1013,7 @@ void commands::cmd_editconfig_lsi_delete(uint64_t dpi, int s){
 	port2.clear();
 	root["params"] = params;
 
-	root["id"] = id;
+	root["id"] = tid;
 
 	stringstream ss;
  	write_formatted(root, ss );	
@@ -1061,7 +1041,7 @@ void commands::cmd_editconfig_lsi_delete(uint64_t dpi, int s){
 	params.clear();
 			
 	//Increment transaction id
-	id++;
+	tid++;
 	
 	//disconnect socket
     cmd_disconnect(s);
@@ -1071,15 +1051,11 @@ AddNFportsOut *commands::cmd_editconfig_NFPorts(AddNFportsIn anpi, int s){
 
 	AddNFportsOut *anf = NULL;
 	
-	char temp[64] = "", tmp[64] = "";
-	
     ssize_t nwritten;
 	
 	char read_buf[4096] = "";
 	
 	int r = 0;
-	
-	locale loc;	
 	
 	map<string, unsigned int> ports;
 	list<string> ports_name_on_switch;
@@ -1104,103 +1080,86 @@ AddNFportsOut *commands::cmd_editconfig_NFPorts(AddNFportsIn anpi, int s){
 
 		params.push_back("Open_vSwitch");
 		
-		/*for each port in the list of nfp*/
+		/*for each port in the list*/
 		for(list<struct nf_port_info>::iterator nfp = nf_ports.begin(); nfp != nf_ports.end(); nfp++)
 		{
-			char ifac[64] = "iface";
-			char p_n[64] = "";
+			char ifac[64];
+			string port_name;
 				
 			//Create the current name of a interface
-			sprintf(temp, "%d", rnumber);
-			strcat(ifac, temp);
+			sprintf(ifac, "iface%d", rnumber);
 			
-			string str = nfp->port_name;
+			string uuid_name = build_port_uuid_name(nfp->port_name, anpi.getDpid());
 				
-			//Create port name to lower case
-			for (string::size_type i=0; i<str.length(); ++i)
-    			str[i] = tolower(str[i], loc);
-    				
-    		//Create the current port name
-			strcpy(tmp, (char *)(str).c_str());
-			sprintf(temp, "%" PRIu64, anpi.getDpid());
-			strcat(tmp, "b");
-			strcat(tmp, temp);
-			strcpy(temp, tmp);
-				
-			for(unsigned int j=0;j<strlen(temp);j++){
-				if(temp[j] == '_')
-					temp[j] = 'p';
-			}
-				
-//			sprintf(temp, "%d", rnumber);
-//			strcat(ifac, temp);
-		
 			first_obj["op"] = "insert";
 			first_obj["table"] = "Interface";
 		
-			sprintf(p_n, "%" PRIu64 "_%s", anpi.getDpid(), nfp->port_name.c_str());
-			row["name"] = p_n;
+			stringstream ss;
+			ss << anpi.getDpid() << '_' << nfp->port_name;
+			port_name = ss.str();
+
+			row["name"] = port_name.c_str();
 			row["type"] = "internal";
 			
 			row["admin_state"] = "up";
 			row["link_state"] = "up";
 			row["ofport"] = rnumber;
 			row["ofport_request"] = rnumber;
-		
+
 			first_obj["row"] = row;
-		
+
 			first_obj["uuid-name"] = ifac;
-		
+
 			params.push_back(first_obj);
-		
+
 			row.clear();
 			first_obj.clear();
-				
+
 			first_obj["op"] = "insert";
 			first_obj["table"] = "Port";
-		
-			row["name"] = p_n;
-		
+
+			row["name"] = port_name.c_str();
+
 			iface.push_back("set");
-	
+
 			iface2.push_back("named-uuid");
 			iface2.push_back(ifac);
-	
+
 			iface1.push_back(iface2);
 			iface.push_back(iface1);
-		
+
 			row["interfaces"] = iface;
-		
+
 			first_obj["row"] = row;
-		
-			first_obj["uuid-name"] = temp;
-		
+
+			first_obj["uuid-name"] = uuid_name.c_str();
+
 			params.push_back(first_obj);
-		
+
 			row.clear();
 			first_obj.clear();
 			iface.clear();
 			iface1.clear();
 			iface2.clear();
-				
+
 			//insert this port name into port_n
-			port_l[anpi.getDpid()].push_back(temp);
-				
+			port_l[anpi.getDpid()].push_back(uuid_name);
+
 			ports[nfp->port_name] = rnumber;
-			
+
 			stringstream pnos;
 			pnos << anpi.getDpid() << "_" << nfp->port_name;
 			ports_name_on_switch.push_back(pnos.str());
-			
+
 			rnumber++;
 		}
-		
+
 		first_obj["op"] = "update";
 		first_obj["table"] = "Bridge";
-			
+
 		third_object.push_back("_uuid");
 		third_object.push_back("==");
-		
+
 		fourth_object.push_back("uuid");
 		fourth_object.push_back(switch_uuid[anpi.getDpid()].c_str());
 		
@@ -1228,27 +1187,12 @@ AddNFportsOut *commands::cmd_editconfig_NFPorts(AddNFportsIn anpi, int s){
 		}
 
 		list<string> ports_name_on_switch;
-		for(list<struct nf_port_info>::iterator nff = nf_ports.begin(); nff != nf_ports.end(); nff++)
+		for(list<struct nf_port_info>::iterator nfp = nf_ports.begin(); nfp != nf_ports.end(); nfp++)
 		{
-			string str = nff->port_name;
-				
-			//Create port name to lower case
-			for (string::size_type i=0; i<str.length(); ++i)
-    			str[i] = tolower(str[i], loc);
-    				
-			strcpy(tmp, (char *)(str).c_str());
-			sprintf(temp, "%" PRIu64, anpi.getDpid());
-			strcat(tmp, "b");
-			strcat(tmp, temp);
-			strcpy(temp, tmp);
-				
-			for(unsigned int j=0;j<strlen(temp);j++){
-				if(temp[j] == '_')
-					temp[j] = 'p';
-			}
+			string uuid_name = build_port_uuid_name(nfp->port_name, anpi.getDpid());
 		
 			port2.push_back("named-uuid");
-			port2.push_back(temp);
+			port2.push_back(uuid_name);
 			port1.push_back(port2);
 			port2.clear();
 		}
@@ -1296,7 +1240,7 @@ AddNFportsOut *commands::cmd_editconfig_NFPorts(AddNFportsIn anpi, int s){
 		port2.clear();
 		root["params"] = params;
 
-		root["id"] = id;
+		root["id"] = tid;
 
 		stringstream ss;
  		write_formatted(root, ss );
@@ -1361,7 +1305,7 @@ AddNFportsOut *commands::cmd_editconfig_NFPorts(AddNFportsIn anpi, int s){
 		params.clear();
 			
 		//Increment transaction id
-		id++;
+		tid++;
 	}
 
 	//disconnect socket
@@ -1379,8 +1323,6 @@ void commands::cmd_editconfig_NFPorts_delete(DestroyNFportsIn dnpi, int s){
 	char read_buf[4096] = "";
 	
 	int r = 0;
-	
-	locale loc;	
 	
 	map<string, unsigned int> ports;
 
@@ -1506,7 +1448,7 @@ void commands::cmd_editconfig_NFPorts_delete(DestroyNFportsIn dnpi, int s){
 		port2.clear();
 		root["params"] = params;
 
-		root["id"] = id;
+		root["id"] = tid;
 
 		stringstream ss;
  		write_formatted(root, ss );
@@ -1534,7 +1476,7 @@ void commands::cmd_editconfig_NFPorts_delete(DestroyNFportsIn dnpi, int s){
 		params.clear();
 			
 		//Increment transaction id
-		id++;
+		tid++;
 		
 		cmd_disconnect(s);
 	}
@@ -1613,8 +1555,6 @@ void commands::cmd_add_virtual_link(string vrt, string trv, char ifac[64], uint6
 	char read_buf[4096] = "";
 	
 	int r = 0;
-	
-	locale loc;	
 	
 	map<string, unsigned int> ports;
 	
@@ -1789,7 +1729,7 @@ void commands::cmd_add_virtual_link(string vrt, string trv, char ifac[64], uint6
 	port2.clear();
 	root["params"] = params;
 
-	root["id"] = id;
+	root["id"] = tid;
 
 	stringstream ss;
  	write_formatted(root, ss );
@@ -1854,7 +1794,7 @@ void commands::cmd_add_virtual_link(string vrt, string trv, char ifac[64], uint6
 	params.clear();
 			
 	//Increment transaction id
-	id++;
+	tid++;
 	
 	rnumber++;
 	
@@ -1895,8 +1835,6 @@ void commands::cmd_delete_virtual_link(uint64_t dpi, uint64_t idp, int s){
 	char read_buf[4096] = "";
 	
 	int r = 0;
-	
-	locale loc;	
 	
 	map<string, unsigned int> ports;
 	
@@ -2017,7 +1955,7 @@ void commands::cmd_delete_virtual_link(uint64_t dpi, uint64_t idp, int s){
 	port2.clear();
 	root["params"] = params;
 
-	root["id"] = id;
+	root["id"] = tid;
 
 	stringstream ss;
  	write_formatted(root, ss );
@@ -2045,7 +1983,7 @@ void commands::cmd_delete_virtual_link(uint64_t dpi, uint64_t idp, int s){
 	params.clear();
 			
 	//Increment transaction id
-	id++;
+	tid++;
 	
 	//disconnect socket
     cmd_disconnect(s);

--- a/orchestrator/network_controller/switch_manager/plugins/ovs-ovsdb/ovsdb_constants.h
+++ b/orchestrator/network_controller/switch_manager/plugins/ovs-ovsdb/ovsdb_constants.h
@@ -7,6 +7,9 @@
 *	@brief: paths of the bash scripts exploited by the plugin
 */
 #define CREATE_VETH_PAIR			"./network_controller/switch_manager/plugins/ovs-ovsdb/scripts/create_veth_pair.sh"
+#ifdef ENABLE_OVSDB_DPDK
+#define PREP_USVHOST_PORT			"./network_controller/switch_manager/plugins/ovs-ovsdb/scripts/prep_usvhost.sh"
+#endif
 #if 0
 #define ACTIVATE_INTERFACE			"./network_controller/switch_manager/plugins/ovs-ovsdb/scripts/activate_interface.sh"
 #endif

--- a/orchestrator/network_controller/switch_manager/plugins/ovs-ovsdb/scripts/prep_usvhost.sh
+++ b/orchestrator/network_controller/switch_manager/plugins/ovs-ovsdb/scripts/prep_usvhost.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+#Author: UNIFY Consortium
+#Date: 2015-01-18
+#Brief: Prepare for a usvhost port creation
+
+#$1 full port name as will be created in OVS
+
+socket_path="/usr/local/var/run/openvswitch/"
+
+port="$1"
+
+if (( $EUID != 0 ))
+then
+    echo "[$0] This script must be executed with ROOT privileges"
+    exit 0
+fi
+
+echo "Cleaning up socket for USVHOST port $port"
+
+rm -f "$socket_path/$port"
+exit 1


### PR DESCRIPTION
The OVS DPDK netdev support by OVS-OVSDB plugin is controlled by the build option ENABLE_OVSDB_DPDK.

Currently working: Docker + usvhost
Currently boken: Ivshmem   (though it worked before recent rebase so should be easy to get back)
