### PR TITLE
OVS-OVSDB: Support for DPDK Ring ports (dpdkr, ivshmem)

### DIFF
--- a/orchestrator/network_controller/switch_manager/plugins/ovs-ovsdb/commands.h
+++ b/orchestrator/network_controller/switch_manager/plugins/ovs-ovsdb/commands.h
@@ -206,7 +206,10 @@ public:
 			]
 		}
 	*/
-	void add_port(string p, uint64_t dnumber, bool is_nf_port, int s, PortType port_type = UNDEFINED_PORT);
+	/**
+	 * Add a port to the LSI identifed by dnumber. Returns the port name on as known on the switch.
+	 */
+	string add_port(string p, uint64_t dnumber, bool is_nf_port, int s, PortType port_type = UNDEFINED_PORT);
 	
 	/**
 	*	Example of command to create a new INTERNAL PORT


### PR DESCRIPTION
Support for DPDK rings in OVS-OVSDB plugin requires additional mapping because OVS requires ports names that start with 'dpdkr' for them to be created as DPDK Rings. Hence we cannot use the normal names resulting from the VNF names as we normally do and have to maintain an additional indirection instead.
