### PR TITLE
Fixed compatibility with old GCC toolchain

### DIFF
--- a/orchestrator/CMakeLists.txt
+++ b/orchestrator/CMakeLists.txt
@@ -471,7 +471,7 @@ LINK_DIRECTORIES(
 
 TARGET_LINK_LIBRARIES( node-orchestrator
 	libpthread.so
-	/usr/local/lib/librofl_common.so
+	librofl_common.so
 	libjson_spirit.so
 	libmicrohttpd.so
 	libboost_system.so

--- a/orchestrator/compute_controller/compute_controller.h
+++ b/orchestrator/compute_controller/compute_controller.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#define __STDC_FORMAT_MACROS
 #include <list>
 
 #include <map>

--- a/orchestrator/compute_controller/plugins/kvm-libvirt/libvirt.h
+++ b/orchestrator/compute_controller/plugins/kvm-libvirt/libvirt.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#define __STDC_FORMAT_MACROS
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>

--- a/orchestrator/compute_controller/startNF_in.h
+++ b/orchestrator/compute_controller/startNF_in.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#define __STDC_FORMAT_MACROS
+
 #include <string>
 #include <map>
 #include <inttypes.h>

--- a/orchestrator/compute_controller/updateNF_in.h
+++ b/orchestrator/compute_controller/updateNF_in.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#define __STDC_FORMAT_MACROS
 #include <string>
 #include <map>
 #include <inttypes.h>

--- a/orchestrator/network_controller/switch_manager/addEndpoint_in.h
+++ b/orchestrator/network_controller/switch_manager/addEndpoint_in.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#define __STDC_FORMAT_MACROS
 #include <string>
 #include <list>
 #include <inttypes.h>

--- a/orchestrator/network_controller/switch_manager/addNFports_in.h
+++ b/orchestrator/network_controller/switch_manager/addNFports_in.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#define __STDC_FORMAT_MACROS
 #include <string>
 #include <list>
 #include <inttypes.h>

--- a/orchestrator/network_controller/switch_manager/addVirtualLink_in.h
+++ b/orchestrator/network_controller/switch_manager/addVirtualLink_in.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 /**

--- a/orchestrator/network_controller/switch_manager/addVirtualLink_out.h
+++ b/orchestrator/network_controller/switch_manager/addVirtualLink_out.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 /**

--- a/orchestrator/network_controller/switch_manager/checkPhysicalPorts_in.h
+++ b/orchestrator/network_controller/switch_manager/checkPhysicalPorts_in.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#define __STDC_FORMAT_MACROS
+
 #include <string>
 #include <list>
 #include <inttypes.h>

--- a/orchestrator/network_controller/switch_manager/createLSIin.h
+++ b/orchestrator/network_controller/switch_manager/createLSIin.h
@@ -6,6 +6,7 @@
 #include "../../compute_controller/nf_type.h"
 #include "../../compute_controller/description.h"
 
+#define __STDC_FORMAT_MACROS
 #include <string>
 #include <list>
 #include <inttypes.h>

--- a/orchestrator/network_controller/switch_manager/destroyEndpoint_in.h
+++ b/orchestrator/network_controller/switch_manager/destroyEndpoint_in.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#define __STDC_FORMAT_MACROS
 #include <string>
 #include <inttypes.h>
 

--- a/orchestrator/network_controller/switch_manager/destroyNFports_in.h
+++ b/orchestrator/network_controller/switch_manager/destroyNFports_in.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#define __STDC_FORMAT_MACROS
 #include <string>
 #include <inttypes.h>
 

--- a/orchestrator/network_controller/switch_manager/destroyVirtualLink_in.h
+++ b/orchestrator/network_controller/switch_manager/destroyVirtualLink_in.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 /**

--- a/orchestrator/network_controller/switch_manager/plugins/ovs-ofconfig/commands.h
+++ b/orchestrator/network_controller/switch_manager/plugins/ovs-ofconfig/commands.h
@@ -1,6 +1,8 @@
 #ifndef OVS_COMMANDS_H_
 #define OVS_COMMANDS_H_ 1
 
+#define __STDC_FORMAT_MACROS
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <string>

--- a/orchestrator/network_controller/switch_manager/plugins/ovs-ovsdb/commands.h
+++ b/orchestrator/network_controller/switch_manager/plugins/ovs-ovsdb/commands.h
@@ -1,6 +1,7 @@
 #ifndef OVS_COMMANDS_H_
 #define OVS_COMMANDS_H_ 1
 
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 #include <arpa/inet.h>
 #include <unistd.h>

--- a/orchestrator/node_resource_manager/graph/low_level_graph/low_level_match.h
+++ b/orchestrator/node_resource_manager/graph/low_level_graph/low_level_match.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 #include <ostream>
 

--- a/orchestrator/node_resource_manager/graph/match.h
+++ b/orchestrator/node_resource_manager/graph/match.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
 #include <rofl/platform/unix/cunixenv.h>

--- a/orchestrator/node_resource_manager/graph/vlan_action.h
+++ b/orchestrator/node_resource_manager/graph/vlan_action.h
@@ -1,6 +1,7 @@
 #ifndef VLAN_ACTION_H_
 #define VLAN_ACTION_H_ 1
 
+#define __STDC_FORMAT_MACROS
 #include "generic_action.h"
 
 #include <inttypes.h>

--- a/orchestrator/node_resource_manager/graph_manager/virtual_link.h
+++ b/orchestrator/node_resource_manager/graph_manager/virtual_link.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 #include <string>
 


### PR DESCRIPTION
Added the macro `__STDC_FORMAT_MACRO` before `#include <inttypes.h>`, since in C++ the macros are not automatically defined just by including the file.
