### PR TITLE
store controllerPort as unsigned instead of string

### DIFF
--- a/orchestrator/network_controller/switch_manager/createLSIin.h
+++ b/orchestrator/network_controller/switch_manager/createLSIin.h
@@ -36,7 +36,7 @@ private:
 	/**
 	*	@brief: TCP port of the Openflow controller
 	*/
-	string controllerPort;
+	unsigned controllerPort;
 
 	/**
 	*	@brief: list of physical ports to be connected to the lsi
@@ -83,7 +83,7 @@ protected:
 
 	//FIXME: endpoints mean "endpoint gre"
 
-	CreateLsiIn(string controllerAddress, string controllerPort, list<string> physicalPortsName, map<string,nf_t>  nf_types, map<string,list<struct nf_port_info> > netFunctionsPortsInfo, map<string,vector<string> > endpointsPortsName, list<uint64_t> vlinksRemoteLsi, string local_ip, string ipsec_certificate)
+	CreateLsiIn(string controllerAddress, unsigned controllerPort, list<string> physicalPortsName, map<string,nf_t>  nf_types, map<string,list<struct nf_port_info> > netFunctionsPortsInfo, map<string,vector<string> > endpointsPortsName, list<uint64_t> vlinksRemoteLsi, string local_ip, string ipsec_certificate)
 		: controllerAddress(controllerAddress), controllerPort(controllerPort),
 		physicalPortsName(physicalPortsName.begin(),physicalPortsName.end()),
 		nf_types(nf_types.begin(),nf_types.end()),
@@ -105,7 +105,7 @@ public:
 		return controllerAddress;
 	}
 
-	string getControllerPort()
+	unsigned getControllerPort()
 	{
 		return controllerPort;
 	}

--- a/orchestrator/network_controller/switch_manager/plugins/ovs-ovsdb/commands.cc
+++ b/orchestrator/network_controller/switch_manager/plugins/ovs-ovsdb/commands.cc
@@ -217,7 +217,7 @@ CreateLsiOut* commands::cmd_editconfig_lsi (CreateLsiIn cli, int s)
 	int l = 0;
 
 	/*Create the current target of a controller*/
-	sprintf(tcp_s, "tcp:%s:%s", cli.getControllerAddress().c_str(), cli.getControllerPort().c_str());
+	sprintf(tcp_s, "tcp:%s:%u", cli.getControllerAddress().c_str(), cli.getControllerPort());
 
 	/*insert Controller*/
 	first_obj["op"] = "insert";

--- a/orchestrator/node_resource_manager/graph_manager/graph_manager.cc
+++ b/orchestrator/node_resource_manager/graph_manager/graph_manager.cc
@@ -31,9 +31,6 @@ GraphManager::GraphManager(int core_mask,set<string> physical_ports,string un_ad
 	pthread_mutex_unlock(&graph_manager_mutex);
 	nameResolverPort = name_resolver_port;
 
-	ostringstream strControllerPort;
-	strControllerPort << controllerPort;
-
 	logger(ORCH_INFO, MODULE_NAME, __FILE__, __LINE__, "Checking the available physical interfaces...");
 	try
 	{
@@ -79,7 +76,7 @@ GraphManager::GraphManager(int core_mask,set<string> physical_ports,string un_ad
 	list<highlevel::EndPointGre> dummy_gre_endpoints;
 	vector<VLink> dummy_virtual_links;
 
-	LSI *lsi = new LSI(string(OF_CONTROLLER_ADDRESS), strControllerPort.str(), phyPorts, dummy_network_functions,
+	LSI *lsi = new LSI(string(OF_CONTROLLER_ADDRESS), controllerPort, phyPorts, dummy_network_functions,
 	dummy_gre_endpoints,dummy_virtual_links,dummy_nfs_ports_type);
 
 	try
@@ -90,7 +87,7 @@ GraphManager::GraphManager(int core_mask,set<string> physical_ports,string un_ad
 		map<string,nf_t>  nf_types;
 		map<string,list<nf_port_info> > netFunctionsPortsInfo;
 
-		CreateLsiIn cli(string(OF_CONTROLLER_ADDRESS),strControllerPort.str(),lsi->getPhysicalPortsName(),nf_types,netFunctionsPortsInfo,gre_endpoints,lsi->getVirtualLinksRemoteLSI(), this->un_address, this->ipsec_certificate);
+		CreateLsiIn cli(string(OF_CONTROLLER_ADDRESS),controllerPort,lsi->getPhysicalPortsName(),nf_types,netFunctionsPortsInfo,gre_endpoints,lsi->getVirtualLinksRemoteLSI(), this->un_address, this->ipsec_certificate);
 
 		CreateLsiOut *clo = switchManager.createLsi(cli);
 
@@ -730,11 +727,8 @@ bool GraphManager::newGraph(highlevel::Graph *graph)
 		nfs_ports_type[nf_id] = nf_ports_type;
 	}
 
-	ostringstream strControllerPort;
-	strControllerPort << controllerPort;
-
 	//Prepare the structure representing the new tenant-LSI
-	LSI *lsi = new LSI(string(OF_CONTROLLER_ADDRESS), strControllerPort.str(), dummyPhyPorts, network_functions,
+	LSI *lsi = new LSI(string(OF_CONTROLLER_ADDRESS), controllerPort, dummyPhyPorts, network_functions,
 		endpointsGre,virtual_links,nfs_ports_type);
 
 	CreateLsiOut *clo = NULL;
@@ -767,7 +761,7 @@ bool GraphManager::newGraph(highlevel::Graph *graph)
 
 		assert(description_gre_endpoints.size() == endpoints_gre.size());
 
-		CreateLsiIn cli(string(OF_CONTROLLER_ADDRESS),strControllerPort.str(), lsi->getPhysicalPortsName(), nf_types, lsi->getNetworkFunctionsPortsInfo(), description_gre_endpoints, lsi->getVirtualLinksRemoteLSI(), string(OF_CONTROLLER_ADDRESS), this->ipsec_certificate);
+		CreateLsiIn cli(string(OF_CONTROLLER_ADDRESS),controllerPort, lsi->getPhysicalPortsName(), nf_types, lsi->getNetworkFunctionsPortsInfo(), description_gre_endpoints, lsi->getVirtualLinksRemoteLSI(), string(OF_CONTROLLER_ADDRESS), this->ipsec_certificate);
 
 		clo = switchManager.createLsi(cli);
 

--- a/orchestrator/node_resource_manager/graph_manager/lsi.cc
+++ b/orchestrator/node_resource_manager/graph_manager/lsi.cc
@@ -11,7 +11,7 @@ static string nf_port_name(const string& nf_id, unsigned int port_id)
 	return ss.str();
 }
 
-LSI::LSI(string controllerAddress, string controllerPort, set<string> physical_ports, list<highlevel::VNFs> network_functions,
+LSI::LSI(string controllerAddress, unsigned controllerPort, set<string> physical_ports, list<highlevel::VNFs> network_functions,
 	list<highlevel::EndPointGre> gre_endpoints_ports, vector<VLink> virtual_links, map<string, map<unsigned int,PortType> > a_nfs_ports_type) :
 		controllerAddress(controllerAddress), controllerPort(controllerPort),
 		virtual_links(virtual_links.begin(),virtual_links.end())
@@ -41,7 +41,7 @@ string LSI::getControllerAddress()
 	return controllerAddress;
 }
 
-string LSI::getControllerPort()
+unsigned LSI::getControllerPort()
 {
 	return controllerPort;
 }

--- a/orchestrator/node_resource_manager/graph_manager/lsi.h
+++ b/orchestrator/node_resource_manager/graph_manager/lsi.h
@@ -42,7 +42,7 @@ private:
 	/**
 	*	@brief: this is the port used by the OF controller for the LSI
 	*/
-	string controllerPort;
+	unsigned controllerPort;
 
 	/**
 	*	@brief: data plane identifier
@@ -133,11 +133,11 @@ private:
 
 public:
 
-	LSI(string controllerAddress, string controllerPort, set<string> physical_ports, list<highlevel::VNFs> network_functions,
+	LSI(string controllerAddress, unsigned controllerPort, set<string> physical_ports, list<highlevel::VNFs> network_functions,
 		list<highlevel::EndPointGre> gre_endpoints_ports, vector<VLink> virtual_links, map<string, map<unsigned int, PortType> > nfs_ports_type);
 
 	string getControllerAddress();
-	string getControllerPort();
+	unsigned getControllerPort();
 
 	list<highlevel::EndPointGre> getEndpointsPorts();
 


### PR DESCRIPTION
these classes are affected:
- LSI
- GraphManager
- CreateLsiIn
